### PR TITLE
IE 8 Support

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,8 @@ var xhr = require('xhr');
 var clone = require('lodash-compat').cloneDeep;
 var hat = require('hat');
 
+var shims = require('./lib/shims.js')();
+
 module.exports = Events;
 
 function Events(options) {

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var xhr = require('xhr');
-var clone = require('clone');
+var clone = require('lodash-compat').cloneDeep;
 var hat = require('hat');
 
 module.exports = Events;

--- a/lib/shims.js
+++ b/lib/shims.js
@@ -1,0 +1,49 @@
+// Shims for .bind() and .toISOString in IE 8
+
+module.exports = function() {
+  if ( !Date.prototype.toISOString ) {         
+      (function() {         
+          function pad(number) {
+              var r = String(number);
+              if ( r.length === 1 ) {
+                  r = '0' + r;
+              }
+              return r;
+          }      
+          Date.prototype.toISOString = function() {
+              return this.getUTCFullYear()
+                  + '-' + pad( this.getUTCMonth() + 1 )
+                  + '-' + pad( this.getUTCDate() )
+                  + 'T' + pad( this.getUTCHours() )
+                  + ':' + pad( this.getUTCMinutes() )
+                  + ':' + pad( this.getUTCSeconds() )
+                  + '.' + String( (this.getUTCMilliseconds()/1000).toFixed(3) ).slice( 2, 5 )
+                  + 'Z';
+          };       
+      }() );
+  }
+
+  if (!Function.prototype.bind) {
+    Function.prototype.bind = function (oThis) {
+      if (typeof this !== "function") {
+        // closest thing possible to the ECMAScript 5 internal IsCallable function
+        throw new TypeError("Function.prototype.bind - what is trying to be bound is not callable");
+      }
+
+      var aArgs = Array.prototype.slice.call(arguments, 1),
+          fToBind = this,
+          fNOP = function () {},
+          fBound = function () {
+            return fToBind.apply(this instanceof fNOP && oThis
+                                   ? this
+                                   : oThis,
+                                 aArgs.concat(Array.prototype.slice.call(arguments)));
+          };
+
+      fNOP.prototype = this.prototype;
+      fBound.prototype = new fNOP();
+
+      return fBound;
+    };
+  }
+}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://www.mapbox.com/"
   },
   "dependencies": {
-    "clone": "^0.2.0",
+    "lodash-compat": "3.3.0",
     "hat": "0.0.3",
     "xhr": "^2.0.1"
   },


### PR DESCRIPTION
Basic support for IE 8 required:
- [x] Deep clone from lodash
- [x] .toISOString() shim
- [x] .bind() shim

Support for IE 8 + 9 sending data through mapbox-events requires figuring out what segment does in [analytics.js](https://github.com/segmentio/analytics.js/blob/master/analytics.js) to get around xhr being blocked.
