### PR TITLE
report version number in event messages

### DIFF
--- a/compatibility_post.js
+++ b/compatibility_post.js
@@ -8,7 +8,7 @@ module.exports = function(events, callback) {
     if (typeof document != 'undefined' && document.location.protocol != protocol[0]) return callback();
 
     xdr = new this._xdr();
-    var url = this.api + '/events/' + this.version + '?access_token=' + this.token;
+    var url = this.api + '/events/v' + this.version.toString() + '?access_token=' + this.token;
 
     xdr.onload = function() { callback(xdr) };
     xdr.onerror = function() {};

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ function Events(options) {
     this.queue = [];
     this.flushAt = Math.max(options.flushAt, 1) || 20;
     this.flushAfter = Math.max(options.flushAfter, 0) || 10000;
-    this.version = options.version || 'v1';
+    this.version = options.version || 1;
     this.api = options.api || 'https://api.tiles.mapbox.com';
     this.token = options.token;
     this._xhr = xhr;
@@ -22,7 +22,7 @@ function Events(options) {
 
 Events.prototype.push = function(obj) {
     obj = _.cloneDeep(obj);
-    obj.version = 1;
+    obj.version = this.version;
     obj.created = +new Date();
     obj.instance = this.instance;
     obj.anonid = this.anonid;

--- a/post.js
+++ b/post.js
@@ -9,6 +9,6 @@ module.exports = function(events, callback) {
             // application/json in as text/plain.
             'Content-Type': 'text/plain'
         },
-        uri: this.api + '/events/' + this.version + '?access_token=' + this.token
+        uri: this.api + '/events/v' + this.version.toString() + '?access_token=' + this.token
     }, callback);
 };

--- a/post_browser.js
+++ b/post_browser.js
@@ -3,7 +3,7 @@ module.exports = function(events, callback) {
     this._xhr({
         method: 'POST',
         body: JSON.stringify(events),
-        uri: this.api + '/events/' + this.version + '?access_token=' + this.token,
+        uri: this.api + '/events/v' + this.version.toString() + '?access_token=' + this.token,
         headers: {
             // Avoid CORS pre-flight OPTIONS request by smuggling
             // application/json in as text/plain.

--- a/test/events.js
+++ b/test/events.js
@@ -63,7 +63,7 @@ test('push v2', function(t) {
     t.plan(9);
     var events = new Events({
         token: 'token',
-        version: 'v2',
+        version: 2,
         flushAt: 5,
         flushAfter: 5000
     }, function(items) {
@@ -76,7 +76,7 @@ test('push v2', function(t) {
         t.equal(JSON.parse(options.body).length, 2);
         t.equal(options.headers['Content-Type'], 'text/plain');
         t.equal(options.method, 'POST');
-        t.equal(body[0].version, 1);
+        t.equal(body[0].version, 2);
         t.equal(typeof body[0].created, 'number');
         t.equal(typeof body[0].instance, 'string');
         t.assert(body[0].instance == body[1].instance, 'instance ids should match');
@@ -91,7 +91,7 @@ test('push - compatibility v2', function(t) {
     t.plan(7);
     var events = new Events({
         token: 'token',
-        version: 'v2',
+        version: 2,
         flushAt: 5,
         flushAfter: 5000
     }, function(items) {
@@ -107,7 +107,7 @@ test('push - compatibility v2', function(t) {
             send: function send(body) {
                 var body = JSON.parse(body);
                 t.equal(body.length, 2);
-                t.equal(body[0].version, 1);
+                t.equal(body[0].version, 2);
                 t.equal(typeof body[0].created, 'number');
                 t.equal(typeof body[0].instance, 'string');
                 t.assert(body[0].instance == body[1].instance, 'instance ids should match');


### PR DESCRIPTION
Spotted the hardcoded `version` attribute too late. This should be set to the version param, if only to avoid confusion. That in turn demands some minor changes to internal accounting & string building.