### PR TITLE
remove lodash dep

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 var xhr = require('xhr');
-var _ = require('lodash-compat');
 var hat = require('hat');
 
 module.exports = Events;
@@ -21,7 +20,7 @@ function Events(options) {
 }
 
 Events.prototype.push = function(obj) {
-    obj = _.cloneDeep(obj);
+    obj = JSON.parse(JSON.stringify(obj));
     obj.version = this.version;
     obj.created = +new Date();
     obj.instance = this.instance;
@@ -29,7 +28,7 @@ Events.prototype.push = function(obj) {
     this.queue.push(obj);
     if (this.queue.length >= this.flushAt) this.flush();
     if (this.timer) clearTimeout(this.timer);
-    if (this.flushAfter) this.timer = setTimeout(_.bind(this.flush, this), this.flushAfter);
+    if (this.flushAfter) this.timer = setTimeout(this.flush.bind(this), this.flushAfter);
 };
 
 Events.prototype.flush = function() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -254,11 +254,6 @@
       "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
       "dev": true
     },
-    "lodash-compat": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/lodash-compat/-/lodash-compat-3.3.0.tgz",
-      "integrity": "sha1-n7VZgfxjfagi1DFRiO72JhKKDMI="
-    },
     "lru-cache": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",

--- a/package.json
+++ b/package.json
@@ -20,10 +20,9 @@
     ]
   },
   "dependencies": {
-    "lodash-compat": "3.3.0",
+    "envify": "^3.2.0",
     "hat": "0.0.3",
-    "xhr": "^2.0.1",
-    "envify": "^3.2.0"
+    "xhr": "^2.0.1"
   },
   "devDependencies": {
     "dox": "^0.6.1",


### PR DESCRIPTION
This library was clocking in around 60k minified thanks to its use of lodash. Even dropping to a [scoped version](https://www.npmjs.com/package/lodash.clonedeep) still kept things up around 15k. This PR reduces things to 7.6k, most of which is coming from `xhr`.

Messages need to survive JSONification to make it through xhr anyway and the `bind()` call seems really straightforward, but I could use another set of :eyes: to make sure I'm not missing something obvious.